### PR TITLE
Add ability to disable users as part of password expiration process & other improvements

### DIFF
--- a/Build/Manage-Module.ps1
+++ b/Build/Manage-Module.ps1
@@ -5,7 +5,7 @@ Invoke-ModuleBuild -ModuleName 'PasswordSolution' {
     # Usual defaults as per standard module
     $Manifest = [ordered] @{
         # Version number of this module.
-        ModuleVersion        = '2.0.X'
+        ModuleVersion        = '2.1.X'
         # Supported PSEditions
         CompatiblePSEditions = @('Desktop', 'Core')
 

--- a/Examples/Example-FindUsersPasswordQualityWithReplacements.ps1
+++ b/Examples/Example-FindUsersPasswordQualityWithReplacements.ps1
@@ -1,0 +1,14 @@
+﻿Import-Module .\PasswordSolution.psd1 -Force
+
+$Replacements = @(
+    New-PasswordConfigurationReplacement -PropertyName 'Country' -Type eq -PropertyReplacementHash @{
+        'PL'      = 'Poland'
+        'DE'      = 'Germany'
+        'AT'      = 'Austria'
+        'IT'      = 'Italy'
+        'Unknown' = 'Not specified in AD'
+    } -OverwritePropertyName 'CountryCode'
+)
+
+$Users = Find-PasswordQuality -Replacements $Replacements
+$Users | Format-Table

--- a/Examples/Example-PasswordSolution-ModernConfiguration01.ps1
+++ b/Examples/Example-PasswordSolution-ModernConfiguration01.ps1
@@ -301,12 +301,12 @@ Start-PasswordSolution {
         EmailText -Text "Here's the summary of password notifications:"
 
         EmailList {
-            EmailListItem -Text "Found users matching rule to send emails: ", $SummaryUsersEmails.Count
-            EmailListItem -Text "Sent emails to users: ", ($SummaryUsersEmails | Where-Object { $_.Status -eq $true }).Count
-            EmailListItem -Text "Couldn't send emails because of no email: ", ($SummaryUsersEmails | Where-Object { $_.Status -eq $false -and $_.StatusError -eq 'No email address for user' }).Count
-            EmailListItem -Text "Couldn't send emails because other reasons: ", ($SummaryUsersEmails | Where-Object { $_.Status -eq $false -and $_.StatusError -ne 'No email address for user' }).Count
-            EmailListItem -Text "Sent emails to managers: ", $SummaryManagersEmails.Count
-            EmailListItem -Text "Sent emails to security: ", $SummaryEscalationEmails.Count
+            EmailListItem -Text "Found users matching rule to send emails: ", $CountUserEmails
+            EmailListItem -Text "Sent emails to users: ", $CountUserEmailsSent
+            EmailListItem -Text "Couldn't send emails because of no email: ", $CountUserEmailsNotSentLackOfEmail
+            EmailListItem -Text "Couldn't send emails because other reasons: ", $CountUserEmailsNotSentOther
+            EmailListItem -Text "Sent emails to managers: ", $CountManagerEmails
+            EmailListItem -Text "Sent emails to security: ", $CountEscalationEmails
         }
 
         EmailText -Text "It took ", $TimeToProcess , " seconds to process the template." -LineBreak

--- a/Examples/Example-PasswordSolution-ModernConfiguration01.ps1
+++ b/Examples/Example-PasswordSolution-ModernConfiguration01.ps1
@@ -109,16 +109,16 @@ Start-PasswordSolution {
         ReminderConfiguration            = {
             # follow expiration days of a user
             New-PasswordConfigurationRuleReminder -Type 'Manager' -DayOfWeek Monday, Wednesday, Friday -ExpirationDays 60 -ComparisonType lt #-ExpirationDays @(-200..-1), 0, 1, 2, 3, 7, 15, 30, 60 -ComparisonType lt
-            New-PasswordConfigurationRuleReminder -Type 'ManagerNotCompliant' -DayOfWeek Friday -ExpirationDays 300 -ComparisonType lt
-            New-PasswordConfigurationRuleReminder -Type 'Security' -DayOfWeek Monday -ExpirationDays -1 -ComparisonType lt
+            #New-PasswordConfigurationRuleReminder -Type 'ManagerNotCompliant' -DayOfWeek Friday -ExpirationDays 300 -ComparisonType lt
+            #New-PasswordConfigurationRuleReminder -Type 'Security' -DayOfWeek Monday -ExpirationDays -1 -ComparisonType lt
         }
-        #ReminderDays                     = '-45', '-30', '-15', '-7' #, 0, 1, 2, 3, 7, 15, 30, 60, 29, 28
+        ReminderDays                     = '-45', '-30', '-15', '-7', -195 #, 0, 1, 2, 3, 7, 15, 30, 60, 29, 28
         IncludeOU                        = @(
             "*OU=Accounts,OU=Administration,DC=ad,DC=evotec,DC=xyz"
             "*OU=Administration,DC=ad,DC=evotec,DC=xyz"
         )
         ManagerReminder                  = $true
-        ProcessManagersOnly              = $true
+        ProcessManagersOnly              = $false
         ManagerNotCompliant              = $true
         ManagerNotCompliantDisplayName   = 'Global Service Desk'
         ManagerNotCompliantEmailAddress  = 'przemyslaw.klys@test.pl'
@@ -129,19 +129,21 @@ Start-PasswordSolution {
         SecurityEscalation               = $true
         SecurityEscalationDisplayName    = 'IT Security'
         SecurityEscalationEmailAddress   = 'przemyslaw.klys@test.pl'
+        #DisableDays                      = @(-171,-170,-172,-200)
+        #DisableType                      = 'in'
+        #DisableWhatIf                    = $true
     }
 
     New-PasswordConfigurationRule @newPasswordConfigurationRuleSplat
 
-
-    # New-PasswordConfigurationRule -Name 'All others' -Enable -ReminderDays @(500..-500), 60, 59, 30, 15, 7, 3, 2, 1, 0, -7, -15, -30, -45 {
-    #     # follow expiration days of a user, you need to enable ManagerReminder for this functionality to work
-    #     New-PasswordConfigurationRuleReminder -Type 'Manager' -ExpirationDays -45, -30, -15, -7, 0, 1, 2, 3, 7, 15, 30, 60
-    #     # use a custom expiration days, and send only on specific days 1st, 10th and 15th of a month
-    #     New-PasswordConfigurationRuleReminder -Type 'Manager' -DayOfMonth 1, 10, 15 -ExpirationDays -45, -30, -15, -7, 0, 1, 2, 3, 7, 15, 30, 60
-    #     # use a custom expiration days (only if it's less then 10 days left), and send only on specific days of a week
-    #     New-PasswordConfigurationRuleReminder -Type 'Manager' -DayOfWeek Monday, Wednesday, Friday -ExpirationDays 10 -ComparisonType 'lt'
-    # } -IncludeExpiring -OverwriteEmailProperty 'extensionAttribute5' -OverwriteManagerProperty 'extensionAttribute1' -ManagerReminder
+    New-PasswordConfigurationRule -Name 'All others' -Enable -ReminderDays @(500..-500), 60, 59, 30, 15, 7, 3, 2, 1, 0, -7, -15, -30, -45 {
+        # follow expiration days of a user, you need to enable ManagerReminder for this functionality to work
+        New-PasswordConfigurationRuleReminder -Type 'Manager' -ExpirationDays -45, -30, -15, -7, 0, 1, 2, 3, 7, 15, 30, 60 -ComparisonType 'in'
+        # use a custom expiration days, and send only on specific days 1st, 10th and 15th of a month
+        #New-PasswordConfigurationRuleReminder -Type 'Manager' -DayOfMonth 1, 10, 15 -ExpirationDays -45, -30, -15, -7, 0, 1, 2, 3, 7, 15, 30, 60 -ComparisonType 'in'
+        # use a custom expiration days (only if it's less then 10 days left), and send only on specific days of a week
+        #New-PasswordConfigurationRuleReminder -Type 'Manager' -DayOfWeek Monday, Wednesday, Friday -ExpirationDays 10 -ComparisonType 'lt'
+    } -ExcludeOUFromOtherRules -IncludeExpiring -OverwriteEmailProperty 'extensionAttribute5' -OverwriteManagerProperty 'extensionAttribute1' -ManagerReminder #-DisableType 'in' -DisableDays @(-171,-200) -DisableWhatIf
 
     # Template to user when sending email to user before password expires
     New-PasswordConfigurationTemplate -Type PreExpiry -Template {

--- a/Examples/Example-ShowUsersPasswordQualityWithReplacements.ps1
+++ b/Examples/Example-ShowUsersPasswordQualityWithReplacements.ps1
@@ -1,0 +1,21 @@
+﻿Import-Module .\PasswordSolution.psd1 -Force
+
+$showPasswordQualitySplat = @{
+    FilePath                = "$PSScriptRoot\Reporting\PasswordQuality_$(Get-Date -f yyyy-MM-dd_HHmmss).html"
+    WeakPasswords           = "Test1", "Test2", "Test3", 'February2023!#!@ok', $Passwords | ForEach-Object { $_ }
+    SeparateDuplicateGroups = $true
+    PassThru                = $true
+    AddWorldMap             = $true
+    LogPath                 = "$PSScriptRoot\Logs\PasswordQuality_$(Get-Date -f yyyy-MM-dd_HHmmss).log"
+    Online                  = $true
+    LogMaximum              = 5
+    Replacements            = New-PasswordConfigurationReplacement -PropertyName 'Country' -Type eq -PropertyReplacementHash @{
+        'PL'      = 'Poland'
+        'DE'      = 'Germany'
+        'AT'      = 'Austria'
+        'IT'      = 'Italy'
+        'Unknown' = 'Not specified in AD'
+    } #-OverwritePropertyName 'CountryCode'
+}
+
+Show-PasswordQuality @showPasswordQualitySplat -Verbose

--- a/Examples/Example-ShowUsersPasswordQualityWithReplacements.ps1
+++ b/Examples/Example-ShowUsersPasswordQualityWithReplacements.ps1
@@ -9,13 +9,13 @@ $showPasswordQualitySplat = @{
     LogPath                 = "$PSScriptRoot\Logs\PasswordQuality_$(Get-Date -f yyyy-MM-dd_HHmmss).log"
     Online                  = $true
     LogMaximum              = 5
-    Replacements            = New-PasswordConfigurationReplacement -PropertyName 'Country' -Type eq -PropertyReplacementHash @{
+    Replacements            = New-PasswordConfigurationReplacement -PropertyName 'ExtensionAttribute4' -Type eq -PropertyReplacementHash @{
         'PL'      = 'Poland'
         'DE'      = 'Germany'
         'AT'      = 'Austria'
         'IT'      = 'Italy'
         'Unknown' = 'Not specified in AD'
-    } #-OverwritePropertyName 'CountryCode'
+    } #-OverwritePropertyName 'AddMe'
 }
 
 Show-PasswordQuality @showPasswordQualitySplat -Verbose

--- a/PasswordSolution.psd1
+++ b/PasswordSolution.psd1
@@ -4,11 +4,11 @@
     CmdletsToExport      = @()
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
-    Copyright            = '(c) 2011 - 2024 Przemyslaw Klys @ Evotec. All rights reserved.'
+    Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'
     Description          = 'This module allows the creation of password expiry emails for users, managers, administrators, and security according to defined templates. It''s able to work with different rules allowing to fully customize who gets the email and when.'
     FunctionsToExport    = @('Find-Password', 'Find-PasswordEntra', 'Find-PasswordNotification', 'Find-PasswordQuality', 'New-PasswordConfigurationEmail', 'New-PasswordConfigurationEntra', 'New-PasswordConfigurationExternalUsers', 'New-PasswordConfigurationOption', 'New-PasswordConfigurationReport', 'New-PasswordConfigurationRule', 'New-PasswordConfigurationRuleReminder', 'New-PasswordConfigurationTemplate', 'New-PasswordConfigurationType', 'Show-PasswordQuality', 'Start-PasswordSolution')
     GUID                 = 'c58ff818-1de6-4500-961c-a243c2043255'
-    ModuleVersion        = '2.0.3'
+    ModuleVersion        = '2.1.0'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{
@@ -21,7 +21,7 @@
     RequiredModules      = @(@{
             Guid          = 'ee272aa8-baaa-4edf-9f45-b6d6f7d844fe'
             ModuleName    = 'PSSharedGoods'
-            ModuleVersion = '0.0.302'
+            ModuleVersion = '0.0.306'
         }, @{
             Guid          = 'a7bdf640-f5cb-4acf-9de0-365b322d245c'
             ModuleName    = 'PSWriteHTML'

--- a/PasswordSolution.psd1
+++ b/PasswordSolution.psd1
@@ -6,7 +6,7 @@
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'
     Description          = 'This module allows the creation of password expiry emails for users, managers, administrators, and security according to defined templates. It''s able to work with different rules allowing to fully customize who gets the email and when.'
-    FunctionsToExport    = @('Find-Password', 'Find-PasswordEntra', 'Find-PasswordNotification', 'Find-PasswordQuality', 'New-PasswordConfigurationEmail', 'New-PasswordConfigurationEntra', 'New-PasswordConfigurationExternalUsers', 'New-PasswordConfigurationOption', 'New-PasswordConfigurationReport', 'New-PasswordConfigurationRule', 'New-PasswordConfigurationRuleReminder', 'New-PasswordConfigurationTemplate', 'New-PasswordConfigurationType', 'Show-PasswordQuality', 'Start-PasswordSolution')
+    FunctionsToExport    = @('Find-Password', 'Find-PasswordEntra', 'Find-PasswordNotification', 'Find-PasswordQuality', 'New-PasswordConfigurationEmail', 'New-PasswordConfigurationEntra', 'New-PasswordConfigurationExternalUsers', 'New-PasswordConfigurationOption', 'New-PasswordConfigurationReplacement', 'New-PasswordConfigurationReport', 'New-PasswordConfigurationRule', 'New-PasswordConfigurationRuleReminder', 'New-PasswordConfigurationTemplate', 'New-PasswordConfigurationType', 'Show-PasswordQuality', 'Start-PasswordSolution')
     GUID                 = 'c58ff818-1de6-4500-961c-a243c2043255'
     ModuleVersion        = '2.1.0'
     PowerShellVersion    = '5.1'

--- a/Private/Invoke-PasswordRuleProcessing.ps1
+++ b/Private/Invoke-PasswordRuleProcessing.ps1
@@ -37,9 +37,29 @@
                 # We don't want to have disabled users
                 continue
             }
+            if ($Rule.ExcludeOUFromOtherRules) {
+                # Rule defined that user within OU's already used in processed Rules are excluded
+                $FoundOU = $false
+                foreach ($OU in $Summary.Tracking.IncludeOU) {
+                    if ($User.OrganizationalUnit -like $OU) {
+                        $FoundOU = $true
+                        break
+                    }
+                }
+                # if OU is found we need to exclude the user
+                if ($FoundOU) {
+                    continue
+                }
+            }
+
             if ($Rule.ExcludeOU.Count -gt 0) {
+                # Rule defined that user within specific OU has to be excluded
                 $FoundOU = $false
                 foreach ($OU in $Rule.ExcludeOU) {
+                    # Lets update global tracking
+                    if ($Summary['Tracking']['ExcludeOU'] -notcontains $OU) {
+                        $Summary['Tracking']['ExcludeOU'].Add($OU)
+                    }
                     if ($User.OrganizationalUnit -like $OU) {
                         $FoundOU = $true
                         break
@@ -54,6 +74,10 @@
                 # Rule defined that only user within specific OU has to be found
                 $FoundOU = $false
                 foreach ($OU in $Rule.IncludeOU) {
+                    # Lets update global tracking
+                    if ($Summary['Tracking']['IncludeOU'] -notcontains $OU) {
+                        $Summary['Tracking']['IncludeOU'].Add($OU)
+                    }
                     if ($User.OrganizationalUnit -like $OU) {
                         $FoundOU = $true
                         break

--- a/Private/Invoke-PasswordRuleProcessing.ps1
+++ b/Private/Invoke-PasswordRuleProcessing.ps1
@@ -20,7 +20,13 @@
         }
         # this will make sure to expand array of multiple arrays of ints if provided
         # for example: (-150..-100),(-60..0), 1, 2, 3
-        $Rule.Reminders = $Rule.Reminders | ForEach-Object { $_ }
+        if ($null -ne $Rule.Reminders) {
+            $Rule.Reminders = $Rule.Reminders | ForEach-Object { $_ }
+        }
+        # Do the same for DisableDays, if provided
+        if ($null -ne $Rule.DisableDays) {
+            $Rule.DisableDays = $Rule.DisableDays | ForEach-Object { $_ }
+        }
         foreach ($User in $CachedUsers.Values) {
             if ($Entra.Enabled) {
                 $UserSearchString = $User.UserPrincipalName

--- a/Private/New-HTMLReport.ps1
+++ b/Private/New-HTMLReport.ps1
@@ -6,9 +6,9 @@
         [System.Collections.IDictionary] $Logging,
         [string] $SearchPath,
         [Array] $Rules,
-        [System.Collections.IDictionary]  $UserSection,
-        [System.Collections.IDictionary]  $ManagerSection,
-        [System.Collections.IDictionary]  $SecuritySection,
+        [System.Collections.IDictionary] $UserSection,
+        [System.Collections.IDictionary] $ManagerSection,
+        [System.Collections.IDictionary] $SecuritySection,
         [System.Collections.IDictionary] $AdminSection,
         [System.Collections.IDictionary] $CachedUsers,
         [System.Collections.IDictionary] $Summary,
@@ -18,7 +18,9 @@
         [System.Collections.IDictionary] $SummarySearch,
         [System.Collections.IDictionary] $Locations,
         [System.Collections.IDictionary] $AllSkipped,
-        [System.Collections.IDictionary] $ExternalSystemReplacements
+        [System.Collections.IDictionary] $ExternalSystemReplacements,
+        $TemplateAdmin,
+        $TemplateAdminSubject
     )
     $TranslateOperators = @{
         'lt' = 'Less than'
@@ -122,7 +124,7 @@
                         New-HTMLSection -HeaderText "Admin Section" {
                             New-HTMLList {
                                 New-HTMLListItem -Text "Enabled: ", $AdminSection.Enable -FontWeight normal, bold -TextDecoration underline, none
-                                New-HTMLListItem -Text "Subject: ", $AdminSection.Subject -FontWeight normal, bold -TextDecoration underline, none
+                                New-HTMLListItem -Text "Subject: ", $TemplateAdminSubject -FontWeight normal, bold -TextDecoration underline, none
                                 New-HTMLListItem -Text "Manager: ", $AdminSection.Manager.DisplayName -FontWeight normal, bold -TextDecoration underline, none
                                 New-HTMLListItem -Text "Manager Email: ", ($AdminSection.Manager.EmailAddress -join ", ") -FontWeight normal, bold -TextDecoration underline, none
                             }

--- a/Private/New-HTMLReport.ps1
+++ b/Private/New-HTMLReport.ps1
@@ -505,7 +505,7 @@
                     New-TableCondition -Name 'PasswordExpired' -BackgroundColor LawnGreen -Value $false -ComparisonType string
                     New-TableCondition -Name 'PasswordExpired' -BackgroundColor Salmon -Value $true -ComparisonType string
                     New-TableCondition -Name 'PasswordNeverExpires' -BackgroundColor LawnGreen -FailBackgroundColor Salmon -Value $false -ComparisonType string
-                } -Filtering
+                } -Filtering -AllProperties
             }
         }
         if ($Report.ShowSearchManagers) {
@@ -521,7 +521,7 @@
                 New-HTMLTable -DataTable $ShowSearchManagers {
                     New-TableHeader -Names 'Status', 'StatusError', 'SentTo', 'StatusWhen' -Title 'Email Summary'
                     New-TableCondition -Name 'Status' -BackgroundColor LawnGreen -FailBackgroundColor Salmon -Value $true -ComparisonType string -HighlightHeaders 'Status', 'StatusWhen', 'StatusError', 'SentTo'
-                } -Filtering
+                } -Filtering -AllProperties
             }
         }
         if ($Report.ShowSearchEscalations) {
@@ -537,7 +537,7 @@
                 New-HTMLTable -DataTable $ShowSearchEscalations {
                     New-TableHeader -Names 'Status', 'StatusError', 'SentTo', 'StatusWhen' -Title 'Email Summary'
                     New-TableCondition -Name 'Status' -BackgroundColor LawnGreen -FailBackgroundColor Salmon -Value $true -ComparisonType string -HighlightHeaders 'Status', 'StatusWhen', 'StatusError', 'SentTo'
-                } -Filtering
+                } -Filtering -AllProperties
             }
         }
         if ($Report.ShowSkippedUsers) {

--- a/Private/Send-PasswordEmail.ps1
+++ b/Private/Send-PasswordEmail.ps1
@@ -52,6 +52,26 @@
             $ExpiryDate = $User.DateExpiry
         }
 
+        # Simplify counting for a user used variables
+        $CountUserEmails = 0
+        $CountUserEmailsSent = 0
+        $CountUserEmailsNotSentLackOfEmail = 0
+        $CountUserEmailsNotSentOther = 0
+        foreach ($User in $SummaryUsersEmails) {
+            $CountUserEmails++
+            if ($User.Status -eq $true) {
+                $CountUserEmailsSent++
+            } else {
+                if ($User.StatusError -eq 'No email address for user') {
+                    $CountUserEmailsNotSentLackOfEmail++
+                } else {
+                    $CountUserEmailsNotSentOther++
+                }
+            }
+        }
+        $CountManagerEmails = $SummaryManagersEmails.Count
+        $CountEscalationEmails = $SummaryEscalationEmails.Count
+
         $SourceParameters = [ordered] @{
             ManagerDisplayName                   = $User.DisplayName
             ManagerUsersTable                    = $ManagedUsers
@@ -60,6 +80,15 @@
             SummaryManagersEmails                = $SummaryManagersEmails
             SummaryUsersEmails                   = $SummaryUsersEmails
             TimeToProcess                        = $TimeToProcess
+
+            # Summary counting
+            CountUserEmails                      = $CountUserEmails
+            CountUserEmailsSent                  = $CountUserEmailsSent
+            CountUserEmailsNotSentLackOfEmail    = $CountUserEmailsNotSentLackOfEmail
+            CountUserEmailsNotSentOther          = $CountUserEmailsNotSentOther
+            CountManagerEmails                   = $CountManagerEmails
+            CountEscalationEmails                = $CountEscalationEmails
+
             # Only works if User is set
             UserPrincipalName                    = $User.UserPrincipalName     # : adm.pklys@ad.evotec.xyz
             SamAccountName                       = $User.SamAccountName        # : adm.pklys

--- a/Private/Send-PasswordManagerNotifications.ps1
+++ b/Private/Send-PasswordManagerNotifications.ps1
@@ -82,6 +82,58 @@
             if ($Logging.NotifyOnManagerSend) {
                 Write-Color -Text "[i] Sending notifications to managers ", $ManagerUser.DisplayName, " (", $ManagerUser.EmailAddress, ") (SendToDefaultEmail: ", $ManagerSection.SendToDefaultEmail, ")" -Color White, Yellow, White, Yellow, White, Yellow, White, Yellow, White, Yellow
             }
+            [Array] $DisabledAccounts = foreach ($ManagedUserDN in $Summary['NotifyManager'][$Manager].ManagerDefault.Keys) {
+                $AccountToDisable = [PSCustomObject] @{
+                    SamAccountName = $ManagedUser.User.SamAccountName
+                    Domain         = $ManagedUser.User.Domain
+                    Disabled       = $null
+                    Error          = $null
+                }
+                $ManagedUser = $Summary['NotifyManager'][$Manager].ManagerDefault[$ManagedUserDN]
+                if ($ManagedUser.Rule -and $null -ne $ManagedUser.Rule.DisableDays) {
+                    $CompareSuccess = $false
+                    # We need to check if the user is in the disable days list
+                    if ($ManagedUser.Rule.DisableType -eq 'in') {
+                        $CompareSuccess = $ManagedUser.User.DaysToExpire -in $ManagedUser.Rule.DisableDays
+                    } elseif ($ManagedUser.Rule.DisableType -eq 'lt') {
+                        $CompareSuccess = $ManagedUser.User.DaysToExpire -lt $ManagedUser.Rule.DisableDays
+                    } elseif ($ManagedUser.Rule.DisableType -eq 'gt') {
+                        $CompareSuccess = $ManagedUser.User.DaysToExpire -gt $ManagedUser.Rule.DisableDays
+                    } elseif ($ManagedUser.Rule.DisableType -eq 'eq') {
+                        $CompareSuccess = $ManagedUser.User.DaysToExpire -eq $ManagedUser.Rule.DisableDays
+                    } else {
+                        Write-Color -Text "[r] Unknown disable type: ", $ManagedUser.Rule.DisableType, " for user ", $ManagedUser.User.DisplayName, " (", $ManagedUser.User.UserPrincipalName, ")" -Color White, Yellow, White, Yellow, White, Yellow, White, Yellow, White, Yellow
+                    }
+                    if ($CompareSuccess) {
+                        # Write-Color -Text "[i] Disabling user ", $ManagedUser.User.DisplayName, " (", $ManagedUser.User.UserPrincipalName, ") (DaysToExpire: ", $ManagedUser.User.DaysToExpire, ")" -Color Yellow, White, Magenta, White, Magenta, White, White, Blue
+                        #$ManagedUser.User
+                        if ($ManagedUser.Rule.DisableWhatIf) {
+                            Write-Color -Text "[i] Disabling user ", $ManagedUser.User.DisplayName, " (", $ManagedUser.User.UserPrincipalName, ")", " would be disabled" -Color Cyan, White, Red, Cyan, Red, Yellow
+                            $AccountToDisable.Disabled = $false
+                            $AccountToDisable.Error = "WhatIf"
+                        } else {
+                            # Disable the user
+                            Write-Color -Text "[i] Disabling user ", $ManagedUser.User.DisplayName, " (", $ManagedUser.User.UserPrincipalName, ")" -Color Cyan, White, Magenta, White, Magenta, White, White, Blue
+                            if ($ManagedUser.User.Enabled) {
+                                try {
+                                    Disable-ADAccount -Identity $ManagedUser.User.DistinguishedName -Confirm:$false -WhatIf:$ManagedUser.Rule.DisableWhatIf -ErrorAction Stop
+                                    $AccountToDisable.Disabled = $true
+                                    $AccountToDisable.Error = $null
+                                } catch {
+                                    $AccountToDisable.Disabled = $false
+                                    $AccountToDisable.Error = $_.Exception.Message
+                                    Write-Color -Text "[r] Disabling user ", $ManagedUser.User.DisplayName, " (", $ManagedUser.User.UserPrincipalName, ") failed: ", $_.Exception.Message -Color White, Yellow, White, Yellow, White, Yellow, White, Yellow, White, Yellow
+                                }
+                            } else {
+                                $AccountToDisable.Disabled = $false
+                                $AccountToDisable.Error = "Already disabled"
+                                Write-Color -Text "[i] User is already disabled: ", $ManagedUser.User.DisplayName, " (", $ManagedUser.User.UserPrincipalName, ")" -Color Cyan, White, Magenta, White, Magenta, White, White, Blue
+                            }
+                        }
+                        $AccountToDisable
+                    }
+                }
+            }
             $EmailResult = Send-PasswordEmail @EmailSplat
             if ($Logging.NotifyOnManagerSend) {
                 if ($EmailResult.Error) {
@@ -109,6 +161,9 @@
                 StatusError              = $EmailResult.Error
                 Accounts                 = $ManagedUsers.SamAccountName
                 AccountsCount            = $ManagedUsers.Count
+                DisabledAccounts         = $DisabledAccounts.SamAccountName
+                DisabledAccountsCount    = $DisabledAccounts.Count
+                DisabledAccountsError    = $DisabledAccounts.Error | Sort-Object -Unique
                 Template                 = 'Unknown'
                 ManagerNotCompliant      = $ManagedUsersManagerNotCompliant.SamAccountName
                 ManagerNotCompliantCount = $ManagedUsersManagerNotCompliant.Count

--- a/Public/Find-Password.ps1
+++ b/Public/Find-Password.ps1
@@ -226,7 +226,7 @@
         }
     }
 
-    Write-Color -Text "[i] ", "Preparing users ", $Users.Count, " for password expirations in forest ", $Forest.Name -Color Yellow, White, Yellow, White, Yellow, White
+    Write-Color -Text "[i] ", "Preparing users ", $Users.Count, " for analysis across the forest ", $Forest.Name -Color Yellow, White, Yellow, White, Yellow, White
     foreach ($OU in $FilterOrganizationalUnit) {
         Write-Color -Text "[i] ", "Filtering users by Organizational Unit ", $OU -Color Yellow, White, Yellow, White
     }

--- a/Public/Find-Password.ps1
+++ b/Public/Find-Password.ps1
@@ -4,7 +4,10 @@
     Scan Active Directory forest for all users and their password expiration date
 
     .DESCRIPTION
-    Scan Active Directory forest for all users and their password expiration date
+    Scan Active Directory forest for all users and their password expiration date.
+    This function retrieves detailed information about user accounts from Active Directory,
+    including password status, manager information, and email addresses.
+    It can scan multiple domains, filter by organizational units, and integrate with external systems.
 
     .PARAMETER Forest
     Target different Forest, by default current forest is used
@@ -16,45 +19,102 @@
     Include only specific domains, by default whole forest is scanned
 
     .PARAMETER ExtendedForestInformation
-    Ability to provide Forest Information from another command to speed up processing
+    Ability to provide Forest Information from another command to speed up processing.
+    This is useful when you already have forest information cached.
 
     .PARAMETER OverwriteEmailProperty
-    Overwrite EmailAddress property with different property name
+    Overwrite EmailAddress property with different property name.
+    Useful when the email address is stored in a non-standard attribute.
 
     .PARAMETER OverwriteManagerProperty
     Overwrite Manager property with different property name.
-    Can use DistinguishedName or SamAccountName
+    Can use DistinguishedName or SamAccountName.
+    This is useful for service accounts or other accounts that don't have a standard manager field in AD.
 
     .PARAMETER RulesProperties
-    Add additional properties to be returned from rules
+    Add additional properties to be returned from rules.
+    These properties will be added to the output objects for use in further processing.
 
     .PARAMETER UsersExternalSystem
+    A dictionary containing external user information that can be used to supplement AD data.
+    This allows integration with external identity management systems.
 
     .PARAMETER ExternalSystemReplacements
+    A dictionary that tracks email replacements made from external systems.
+    This helps maintain a record of changes for auditing purposes.
 
     .PARAMETER FilterOrganizationalUnit
+    Filter results to include only users from specified organizational units.
+    This helps reduce processing time for large domains when only specific OUs are needed.
 
     .PARAMETER SearchBase
+    Limit the search to specific containers in Active Directory.
+    Provides an alternative way to filter results by specifying exact search paths.
 
     .PARAMETER AsHashTable
+    Return results as a hashtable instead of objects.
+    This is useful for lookups when you need to quickly find specific users.
 
     .PARAMETER AsHashTableObject
+    Return results as a hashtable of ordered dictionaries instead of PSObjects.
+    This gives more flexibility when manipulating the results programmatically.
 
     .PARAMETER AddEmptyProperties
+    Add empty properties to the output objects.
+    Useful when you need consistent object properties even when some data is missing.
 
     .PARAMETER ReturnObjectsType
+    Specify which types of objects to return (Users, Contacts).
+    Default is both Users and Contacts.
 
     .PARAMETER Cache
+    A dictionary used to cache user information for faster processing.
+    Particularly useful when dealing with large datasets.
 
     .PARAMETER HashtableField
+    Field to use as the key when returning results as a hashtable.
+    Default is 'DistinguishedName'.
 
     .PARAMETER CacheManager
+    A dictionary used to cache manager information for faster processing.
+
+    .PARAMETER Replacements
+    A list of replacement configurations for property values.
+    Allows for standardizing or translating values in the result set.
 
     .EXAMPLE
-    Find-Password | ft
+    Find-Password | Format-Table
+
+    Retrieves all users from the current forest and displays them in a table format.
+
+    .EXAMPLE
+    Find-Password -IncludeDomains "contoso.com" -FilterOrganizationalUnit "OU=Sales,DC=contoso,DC=com"
+
+    Retrieves users only from the contoso.com domain, filters to only those in the Sales OU,
+    and then further filters to show only users with expired passwords.
+
+    .EXAMPLE
+    $replacements = @(
+        New-PasswordConfigurationReplacement -PropertyName 'Country' -Type eq -PropertyReplacementHash @{
+            'PL' = 'Poland'
+            'DE' = 'Germany'
+        } -OverwritePropertyName 'CountryCode'
+    )
+    Find-Password -Replacements $replacements | Select-Object SamAccountName, CountryCode, Country
+
+    Retrieves users and replaces country codes with full country names using the specified replacement configuration.
 
     .NOTES
-    General notes
+    This function is part of the PasswordSolution module.
+    It requires Active Directory PowerShell module to be installed.
+
+    Performance considerations:
+    - For large environments, consider using filters like FilterOrganizationalUnit or SearchBase
+    - Pre-caching forest information can speed up execution when running multiple queries
+    - Using AsHashTable can improve lookup performance for subsequent operations
+
+    For integration with external systems, use the UsersExternalSystem parameter with a properly
+    configured external user repository.
     #>
     [CmdletBinding()]
     param(

--- a/Public/Find-PasswordQuality.ps1
+++ b/Public/Find-PasswordQuality.ps1
@@ -33,11 +33,28 @@
     .PARAMETER ExtendedForestInformation
     Ability to provide Forest Information from another command to speed up processing
 
+    .PARAMETER Replacements
+    Ability to provide replacements for properties to be used in the output
+
     .EXAMPLE
     Find-PasswordQuality -WeakPasswords "Test1", "Test2", "Test3"
 
     .EXAMPLE
     Find-PasswordQuality -WeakPasswords "Test1", "Test2", "Test3" -IncludeStatistics
+
+    .EXAMPLE
+    $Replacements = @(
+        New-PasswordConfigurationReplacement -PropertyName 'Country' -Type eq -PropertyReplacementHash @{
+            'PL'      = 'Poland'
+            'DE'      = 'Germany'
+            'AT'      = 'Austria'
+            'IT'      = 'Italy'
+            'Unknown' = 'Poland'
+        } -OverwritePropertyName 'CountryCode'
+    )
+
+    $Users = Find-PasswordQuality -Replacements $Replacements
+    $Users | Format-Table
 
     .NOTES
     General notes
@@ -53,7 +70,8 @@
         [alias('ForestName')][string] $Forest,
         [string[]] $ExcludeDomains,
         [alias('Domain', 'Domains')][string[]] $IncludeDomains,
-        [System.Collections.IDictionary] $ExtendedForestInformation
+        [System.Collections.IDictionary] $ExtendedForestInformation,
+        [System.Collections.IDictionary[]] $Replacements
     )
 
     $PropertiesToAdd = @(
@@ -104,7 +122,7 @@
         Write-Color -Text "[e] ", "DSInternals module is not installed. Please install it using Install-Module DSInternals -Verbose" -Color Yellow, Red
         return
     }
-    $AllUsers = Find-Password -AsHashTable -HashtableField NetBiosSamAccountName -ReturnObjectsType Users -AsHashTableObject -AddEmptyProperties $PropertiesToAdd -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains
+    $AllUsers = Find-Password -AsHashTable -HashtableField NetBiosSamAccountName -ReturnObjectsType Users -AsHashTableObject -AddEmptyProperties $PropertiesToAdd -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -Replacements $Replacements
 
     Write-Color -Text "[i] ", "Discovering forest information" -Color Yellow, Gray, White, Yellow, White, Yellow, White
     $ForestInformation = Get-WinADForestDetails -PreferWritable -Forest $Forest -ExcludeDomains $ExcludeDomains -IncludeDomains $IncludeDomains -ExtendedForestInformation $ExtendedForestInformation

--- a/Public/New-PasswordConfigurationReplacement.ps1
+++ b/Public/New-PasswordConfigurationReplacement.ps1
@@ -1,0 +1,92 @@
+﻿function New-PasswordConfigurationReplacement {
+    <#
+    .SYNOPSIS
+    Password configuration replacement function for replacing properties in the password configuration
+
+    .DESCRIPTION
+    Password configuration replacement function for replacing properties in the password configuration
+    This function is used to create a replacement configuration for password properties.
+    It takes a property name, a type of comparison, a hash table for property replacements, and an optional overwrite property name.
+    It provides ability to replace specific value on given user object, on given property with different value.
+    For example user having ExtensionAttribute1 with value 'PL' can be replaced with 'Poland'.
+
+    .PARAMETER PropertyName
+    Property name to be replaced in the password configuration.
+    This is the name of the property in the password configuration that will be replaced.
+
+    .PARAMETER Type
+    Type of comparison to be used for the replacement.
+    This parameter specifies the type of comparison to be used when replacing the property value.
+
+    .PARAMETER PropertyReplacementHash
+    Hash table containing the property replacements to be made.
+    This parameter specifies the hash table that contains the mappings of property values to be replaced.
+
+    .PARAMETER OverwritePropertyName
+    Name of the property to be overwritten in the password configuration.
+    This parameter specifies the name of the property that will be overwritten in the password configuration.
+    This is an optional parameter.
+    If the property doesn't exists, it will be added.
+    If the property exists, it will be overwritten regardless of it's value.
+
+    .EXAMPLE
+    $showPasswordQualitySplat = @{
+        FilePath                = "$PSScriptRoot\Reporting\PasswordQuality_$(Get-Date -f yyyy-MM-dd_HHmmss).html"
+        WeakPasswords           = "Test1", "Test2", "Test3", 'February2023!#!@ok', $Passwords | ForEach-Object { $_ }
+        SeparateDuplicateGroups = $true
+        PassThru                = $true
+        AddWorldMap             = $true
+        LogPath                 = "$PSScriptRoot\Logs\PasswordQuality_$(Get-Date -f yyyy-MM-dd_HHmmss).log"
+        Online                  = $true
+        LogMaximum              = 5
+        Replacements            = New-PasswordConfigurationReplacement -PropertyName 'Country' -Type eq -PropertyReplacementHash @{
+            'PL'      = 'Poland'
+            'DE'      = 'Germany'
+            'AT'      = 'Austria'
+            'IT'      = 'Italy'
+            'Unknown' = 'Not specified in AD'
+        } -OverwritePropertyName 'AddMe'
+    }
+
+    Show-PasswordQuality @showPasswordQualitySplat -Verbose
+
+    .EXAMPLE
+    $Replacements = @(
+        New-PasswordConfigurationReplacement -PropertyName 'Country' -Type eq -PropertyReplacementHash @{
+            'PL'      = 'Poland'
+            'DE'      = 'Germany'
+            'AT'      = 'Austria'
+            'IT'      = 'Italy'
+            'Unknown' = 'Not specified in AD'
+        } -OverwritePropertyName 'CountryCode'
+    )
+
+    $Users = Find-PasswordQuality -Replacements $Replacements
+    $Users | Format-Table
+
+    .NOTES
+    General notes
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string] $PropertyName,
+        [ValidateSet('eq')][string] $Type = 'eq',
+        [Parameter(Mandatory)][System.Collections.IDictionary] $PropertyReplacementHash,
+        [string] $OverwritePropertyName
+    )
+    if ($PropertyReplacementHash.Count -eq 0) {
+        Write-Color -Text '[-] ', "Couldn't create replacement configuration as the hash is empty. Please fix 'New-PasswordConfigurationReplacement'" -Color Yellow, White
+        return
+    }
+
+    $Output = [ordered] @{
+        Type     = "PasswordConfigurationReplacement"
+        Settings = @{
+            PropertyName            = $PropertyName
+            Type                    = $Type
+            PropertyReplacementHash = $PropertyReplacementHash
+            OverwritePropertyName   = $OverwritePropertyName
+        }
+    }
+    $Output
+}

--- a/Public/Show-PasswordQuality.ps1
+++ b/Public/Show-PasswordQuality.ps1
@@ -301,7 +301,7 @@
                     New-HTMLTableCondition -Name $Property -ComparisonType string -Operator eq -Value $true -BackgroundColor Salmon -FailBackgroundColor LightGreen
                 }
                 New-HTMLTableCondition -Name 'DuplicatePasswordGroups' -ComparisonType string -Operator ne -Value "" -BackgroundColor Orange -FailBackgroundColor LightGreen
-            } -ScrollX -ExcludeProperty 'RuleName', 'RuleOptions', 'CountryCode', 'Type', 'ManagerDN', 'DistinguishedName', 'MemberOf'
+            } -ScrollX -ExcludeProperty 'RuleName', 'RuleOptions', 'CountryCode', 'Type', 'ManagerDN', 'DistinguishedName', 'MemberOf' -AllProperties
 
         }
         if ($SeparateDuplicateGroups) {

--- a/Public/Show-PasswordQuality.ps1
+++ b/Public/Show-PasswordQuality.ps1
@@ -37,6 +37,29 @@
     .PARAMETER SeparateDuplicateGroups
     If specified, report will show duplicate groups separately, one group per tab.
 
+    .PARAMETER PassThru
+    If specified, the function will return PowerShell object with all relevant information.
+
+    .PARAMETER AddWorldMap
+    If specified, a world map will be added to the report.
+
+    .PARAMETER LogFile
+    Path to the log file where the script will write its log entries.
+
+    .PARAMETER LogMaximum
+    Maximum number of files to keep in the log folder.
+
+    .PARAMETER LogShowTime
+    If specified, the log in console will show time on the left side.
+
+    .PARAMETER LogTimeFormat
+    Format of the time in the log file.
+
+    Default is "yyyy-MM-dd HH:mm:ss".
+
+    .PARAMETER Replacements
+    List of replacements to be used in the report.
+
     .EXAMPLE
     Show-PasswordQuality -FilePath $PSScriptRoot\Reporting\PasswordQuality.html -Online -WeakPasswords "Test1", "Test2", "Test3" -Verbose
 
@@ -65,7 +88,8 @@
         [alias('LogFile')][string] $LogPath,
         [int] $LogMaximum,
         [switch] $LogShowTime,
-        [string] $LogTimeFormat = "yyyy-MM-dd HH:mm:ss"
+        [string] $LogTimeFormat = "yyyy-MM-dd HH:mm:ss",
+        [System.Collections.IDictionary[]] $Replacements
     )
     $TimeStart = Start-TimeLog
     $Script:Reporting = [ordered] @{}
@@ -91,6 +115,9 @@
         ExcludeDomains                = $ExcludeDomains
         IncludeDomains                = $IncludeDomains
         ExtendedForestInformation     = $ExtendedForestInformation
+    }
+    if ($Replacements) {
+        $findPasswordQualitySplat['Replacements'] = $Replacements
     }
     $PasswordQuality = Find-PasswordQuality @findPasswordQualitySplat
     if (-not $PasswordQuality) {

--- a/Public/Start-PasswordSolution.ps1
+++ b/Public/Start-PasswordSolution.ps1
@@ -147,7 +147,10 @@
     $Summary['NotifyManager'] = [ordered] @{}
     $Summary['NotifySecurity'] = [ordered] @{}
     $Summary['Rules'] = [ordered] @{}
-
+    $Summary['Tracking'] = [ordered] @{
+        'IncludeOU' = [System.Collections.Generic.List[string]]::new()
+        'ExcludeOU' = [System.Collections.Generic.List[string]]::new()
+    }
     $AllSkipped = [ordered] @{}
     $Locations = [ordered] @{}
 
@@ -332,6 +335,8 @@
                 ExternalSystemReplacements = $ExternalSystemReplacements
                 TemplateAdmin              = $TemplateAdmin
                 TemplateAdminSubject       = $TemplateAdminSubject
+                SearchBase                 = $SearchBase
+                FilterOrganizationalUnit   = $FilterOrganizationalUnit
             }
             New-HTMLReport @ReportSettings
 


### PR DESCRIPTION
This pull request includes several updates to the `PasswordSolution` module, focusing on version updates, new features, and enhancements to existing functionality. The most important changes include updating the module version, adding new cmdlets and parameters, and improving the HTML report generation.

## The important bits:
- `New-PasswordConfigurationRule` now can take `ExcludeOUFromOtherRules` to be used as a last rule that allows the last rule to not include not matched accounts that were processed in earlier IncludeOU scenarios but didn't hit the reminder days. 
- `New-PasswordConfigurationRule` now can take `DisableDays`, `DisableType` and `DisableWhatIf` to allow disabling of users once they reach certain thresholds of not changing passwords
- Improvements to HTML reporting
- Few other optimizations

### Version Updates:
* Updated `ModuleVersion` to `2.1.X` in `Build/Manage-Module.ps1`.
* Updated `ModuleVersion` to `2.1.0` and `PSSharedGoods` dependency version to `0.0.306` in `PasswordSolution.psd1` [[1]](diffhunk://#diff-b7e16a6e30ef6608b7dd26ef30398eeb97a910663452a8ea85e520bc1696674cL7-R11) [[2]](diffhunk://#diff-b7e16a6e30ef6608b7dd26ef30398eeb97a910663452a8ea85e520bc1696674cL24-R24).

### New Features:
* Added new cmdlet `New-PasswordConfigurationReplacement` and included it in the `FunctionsToExport` list in `PasswordSolution.psd1`.
* Introduced new parameters `TemplateAdmin`, `TemplateAdminSubject`, `FilterOrganizationalUnit`, and `SearchBase` in `Private/New-HTMLReport.ps1`.

### Enhancements:
* Improved the `EmailList` section in `Examples/Example-PasswordSolution-ModernConfiguration01.ps1` by using more descriptive variable names for email counts.
* Enhanced HTML report generation in `Private/New-HTMLReport.ps1` by adding conditions for the `Disabled` and `DisabledError` fields and enabling horizontal scrolling for tables [[1]](diffhunk://#diff-f0ddc64ec4fef6c61a344b30b367ac70e683c82952321ffaa89ef93ea67966d2R94-R131) [[2]](diffhunk://#diff-f0ddc64ec4fef6c61a344b30b367ac70e683c82952321ffaa89ef93ea67966d2L125-R165) [[3]](diffhunk://#diff-f0ddc64ec4fef6c61a344b30b367ac70e683c82952321ffaa89ef93ea67966d2L427-R471) [[4]](diffhunk://#diff-f0ddc64ec4fef6c61a344b30b367ac70e683c82952321ffaa89ef93ea67966d2L442-R488) [[5]](diffhunk://#diff-f0ddc64ec4fef6c61a344b30b367ac70e683c82952321ffaa89ef93ea67966d2L457-R503) [[6]](diffhunk://#diff-f0ddc64ec4fef6c61a344b30b367ac70e683c82952321ffaa89ef93ea67966d2L506-R556) [[7]](diffhunk://#diff-f0ddc64ec4fef6c61a344b30b367ac70e683c82952321ffaa89ef93ea67966d2L522-R573) [[8]](diffhunk://#diff-f0ddc64ec4fef6c61a344b30b367ac70e683c82952321ffaa89ef93ea67966d2L538-R589) [[9]](diffhunk://#diff-f0ddc64ec4fef6c61a344b30b367ac70e683c82952321ffaa89ef93ea67966d2L562-R613) [[10]](diffhunk://#diff-f0ddc64ec4fef6c61a344b30b367ac70e683c82952321ffaa89ef93ea67966d2L572-R623).

### Bug Fixes:
* Added checks for `Rule.Reminders` and `Rule.DisableDays` to ensure they are properly expanded in `Private/Invoke-PasswordRuleProcessing.ps1` [[1]](diffhunk://#diff-6f719e19c7e1a78b01770517da6ca268ce6f5ba98f70574bcf6e1849a93bca0aR23-R29) [[2]](diffhunk://#diff-6f719e19c7e1a78b01770517da6ca268ce6f5ba98f70574bcf6e1849a93bca0aR40-R62) [[3]](diffhunk://#diff-6f719e19c7e1a78b01770517da6ca268ce6f5ba98f70574bcf6e1849a93bca0aR77-R80).

### Documentation:
* Added example scripts to demonstrate the usage of the new `New-PasswordConfigurationReplacement` cmdlet in `Examples/Example-FindUsersPasswordQualityWithReplacements.ps1` and `Examples/Example-ShowUsersPasswordQualityWithReplacements.ps1` [[1]](diffhunk://#diff-58822fa82ae80763d2dc31b6d79d19af487bcc8d50a81cf4b7354dd1ca813d33R1-R14) [[2]](diffhunk://#diff-899aa12d29ecc3539e07f012e927dd1a8e356223a4af90bf5f07df4b24245883R1-R21).