### PR TITLE
Fix display output

### DIFF
--- a/Examples/Example-PasswordSolution-ModernConfiguration01.ps1
+++ b/Examples/Example-PasswordSolution-ModernConfiguration01.ps1
@@ -136,7 +136,7 @@ Start-PasswordSolution {
 
     New-PasswordConfigurationRule @newPasswordConfigurationRuleSplat
 
-    New-PasswordConfigurationRule -Name 'All others' -Enable -ReminderDays @(500..-500), 60, 59, 30, 15, 7, 3, 2, 1, 0, -7, -15, -30, -45 {
+    New-PasswordConfigurationRule -Name 'All others' -Enable -ReminderDays @(500..-500), 60, 59, 30, 15, 7, 3, 2, 1, 0, -7, -15, -30, -45, 600, -505 {
         # follow expiration days of a user, you need to enable ManagerReminder for this functionality to work
         New-PasswordConfigurationRuleReminder -Type 'Manager' -ExpirationDays -45, -30, -15, -7, 0, 1, 2, 3, 7, 15, 30, 60 -ComparisonType 'in'
         # use a custom expiration days, and send only on specific days 1st, 10th and 15th of a month

--- a/Private/Fromat-ReminderDays.ps1
+++ b/Private/Fromat-ReminderDays.ps1
@@ -1,0 +1,86 @@
+﻿function Format-ReminderDays {
+    <#
+    .SYNOPSIS
+    Formats an array of reminder days into a readable, concise format.
+
+    .DESCRIPTION
+    This function accepts an array of numbers (which may include nested arrays)
+    and always sorts them in ascending order. It then groups contiguous sequences
+    (where each subsequent number is either equal to or exactly 1 greater than the previous)
+    and formats groups of three or more unique numbers as a range. For clarity, if any
+    number in the range is negative the range is displayed using " to " (e.g. "-500 to 500")
+    to avoid confusion with hyphenated negatives.
+
+    .PARAMETER Days
+    An array of integers (or nested arrays of integers) representing reminder days.
+
+    .EXAMPLE
+    Format-ReminderDays -Days @(1,2,3,7,30)
+    # Returns: "1-3, 7, 30"
+
+    .EXAMPLE
+    $xxx = @(500..-500), 60, 59, 30, 15, 7, 3, 2, 1, 0, -7, -15, -30, -45, 600, -505
+    Format-ReminderDays -Days $xxx
+    # Returns: "-505, -500 to 500, 600"
+
+    .EXAMPLE
+    Format-ReminderDays -Days @(15..-500), 60, 59, 30, 15, 7, 3, 2, 1, 0, -7, -15, -30, -45, 600, -505
+    # Returns: -505, -500 to 15, 30, 59, 60, 600
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [Array]$Days
+    )
+
+    # Flatten the input array (to handle nested arrays like those produced by ranges)
+    $flatDays = @()
+    foreach ($item in $Days) {
+        if ($item -is [Array]) {
+            $flatDays += $item
+        } else {
+            $flatDays += $item
+        }
+    }
+
+    # Convert all items to integers.
+    $flatDays = $flatDays | ForEach-Object { [int]$_ }
+
+    # Always sort in ascending order.
+    $sortedDays = $flatDays | Sort-Object
+
+    # Group contiguous numbers.
+    $groups = @()
+    $currentGroup = @($sortedDays[0])
+    for ($i = 1; $i -lt $sortedDays.Count; $i++) {
+        $current = $sortedDays[$i]
+        $previous = $sortedDays[$i - 1]
+        # Group if the current number is equal (duplicate) or exactly 1 greater than the previous.
+        if ($current -eq $previous -or $current -eq $previous + 1) {
+            $currentGroup += $current
+        } else {
+            $groups += , @($currentGroup)
+            $currentGroup = @($current)
+        }
+    }
+    $groups += , @($currentGroup)
+
+    # Format each group into a string.
+    $formattedGroups = foreach ($group in $groups) {
+        # Count unique numbers in the group.
+        $uniqueCount = ($group | Select-Object -Unique).Count
+        if ($uniqueCount -ge 3) {
+            # Use " to " when any value is negative (for clarity)
+            if ($group[0] -lt 0 -or $group[-1] -lt 0) {
+                "$($group[0]) to $($group[-1])"
+            } else {
+                "$($group[0])-$($group[-1])"
+            }
+        } else {
+            # For groups with fewer than 3 unique numbers, list the numbers separated by commas.
+            $group -join ", "
+        }
+    }
+
+    return ($formattedGroups -join ", ")
+}

--- a/Private/New-HTMLReport.ps1
+++ b/Private/New-HTMLReport.ps1
@@ -186,7 +186,7 @@
                                     New-HTMLListItem -Text "Rule ", $Rule.Name, " is ", "disabled" -FontWeight normal, bold, normal, bold, normal, normal -Color None, None, None, Red
                                 }
                                 New-HTMLList {
-                                    New-HTMLListItem -Text "Notify till expiry on ", $($Rule.Reminders -join ","), " day " -FontWeight normal, bold, normal
+                                    New-HTMLListItem -Text "Notify till expiry on ", $(Format-ReminderDays -Days $Rule.Reminders), " day" -FontWeight normal, bold, normal
                                     if ($Rule.IncludeExpiring) {
                                         New-HTMLListItem -Text "Include expiring accounts is ", "enabled" -FontWeight bold, bold -Color None, Green
                                     } else {
@@ -231,9 +231,9 @@
                                                             New-HTMLList {
                                                                 if ($Rule.SendToManager.Manager.Reminders.Default.Enable) {
                                                                     if ($Rule.SendToManager.Manager.Reminders.Default.Reminder) {
-                                                                        New-HTMLListItem -Text "Default ", "is enabled", " sent on ", $($Rule.SendToManager.Manager.Reminders.Default.Reminder -join ", "), " days to expiry of user." -FontWeight normal, bold, normal, bold, normal -Color None, Green, None, Green
+                                                                        New-HTMLListItem -Text "Default ", "is enabled", " sent on ", $(Format-ReminderDays -Days $Rule.SendToManager.Manager.Reminders.Default.Reminder), " days to expiry of user." -FontWeight normal, bold, normal, bold, normal -Color None, Green, None, Green
                                                                     } else {
-                                                                        New-HTMLListItem -Text "Default ", "is enabled", " sent on ", $($Rule.Reminders -join ", "), " days to expiry of user." -FontWeight normal, bold, normal, bold, normal -Color None, Green, None, Green
+                                                                        New-HTMLListItem -Text "Default ", "is enabled", " sent on ", $(Format-ReminderDays -Days $Rule.Reminders), " days to expiry of user." -FontWeight normal, bold, normal, bold, normal -Color None, Green, None, Green
                                                                     }
                                                                 } else {
                                                                     New-HTMLListItem -Text "Default rule is ", "disabled" -FontWeight bold, bold -Color None, Red
@@ -276,9 +276,9 @@
                                                             New-HTMLList {
                                                                 if ($Rule.SendToManager.ManagerNotCompliant.Reminders.Default.Enable) {
                                                                     if ($Rule.SendToManager.ManagerNotCompliant.Reminders.Default.Reminder) {
-                                                                        New-HTMLListItem -Text "Default ", "is enabled", " sent on ", $($Rule.SendToManager.ManagerNotCompliant.Reminders.Default.Reminder -join ", "), " days to expiry of user." -FontWeight normal, bold, normal, bold, normal -Color None, Green, None, Green
+                                                                        New-HTMLListItem -Text "Default ", "is enabled", " sent on ", $(Format-ReminderDays -Days $Rule.SendToManager.ManagerNotCompliant.Reminders.Default.Reminder), " days to expiry of user." -FontWeight normal, bold, normal, bold, normal -Color None, Green, None, Green
                                                                     } else {
-                                                                        New-HTMLListItem -Text "Default ", "is enabled", " sent on ", $($Rule.Reminders -join ", "), " days to expiry of user." -FontWeight normal, bold, normal, bold, normal -Color None, Green, None, Green
+                                                                        New-HTMLListItem -Text "Default ", "is enabled", " sent on ", $(Format-ReminderDays -Days $Rule.Reminders), " days to expiry of user." -FontWeight normal, bold, normal, bold, normal -Color None, Green, None, Green
                                                                     }
                                                                 } else {
                                                                     New-HTMLListItem -Text "Default rule is ", "disabled" -FontWeight bold, bold -Color None, Red
@@ -328,9 +328,9 @@
                                                                         #>
                                                                 if ($Rule.SendToManager.SecurityEscalation.Reminders.Default.Enable) {
                                                                     if ($Rule.SendToManager.SecurityEscalation.Reminders.Default.Reminder) {
-                                                                        New-HTMLListItem -Text "Default ", "is enabled", " sent on ", $($Rule.SendToManager.SecurityEscalation.Reminders.Default.Reminder -join ", "), " days to expiry of user." -FontWeight normal, bold, normal, bold, normal -Color None, Green, None, Green
+                                                                        New-HTMLListItem -Text "Default ", "is enabled", " sent on ", $(Format-ReminderDays -Days $Rule.SendToManager.SecurityEscalation.Reminders.Default.Reminder), " days to expiry of user." -FontWeight normal, bold, normal, bold, normal -Color None, Green, None, Green
                                                                     } else {
-                                                                        New-HTMLListItem -Text "Default ", "is enabled", " sent on ", $($Rule.Reminders -join ", "), " days to expiry of user." -FontWeight normal, bold, normal, bold, normal -Color None, Green, None, Green
+                                                                        New-HTMLListItem -Text "Default ", "is enabled", " sent on ", $(Format-ReminderDays -Days $Rule.Reminders), " days to expiry of user." -FontWeight normal, bold, normal, bold, normal -Color None, Green, None, Green
                                                                     }
                                                                 } else {
                                                                     New-HTMLListItem -Text "Default rule is ", "disabled" -FontWeight bold, bold -Color None, Red


### PR DESCRIPTION
Resolves:
- https://github.com/EvotecIT/PasswordSolution/issues/10

This pull request includes several changes to improve the handling and formatting of reminder days in the password solution configuration and HTML report generation. The key changes are the addition of a new function to format reminder days and the integration of this function into various parts of the codebase.

### Key Changes:

#### New Function Addition:
* [`Private/Fromat-ReminderDays.ps1`](diffhunk://#diff-253ad1d9b509599524be32a26ad4dff06f0ad4e4efc6a100fe662b3d61561179R1-R86): Added a new function `Format-ReminderDays` to format an array of reminder days into a readable, concise format. This function sorts the days, groups contiguous sequences, and formats groups of three or more unique numbers as ranges.

#### Integration of New Function:
* `Private/New-HTMLReport.ps1`: Updated several instances to use the new `Format-ReminderDays` function for formatting reminder days in HTML list items.
  * Modified the `New-HTMLListItem` to format `$Rule.Reminders` using `Format-ReminderDays`.
  * Updated the `New-HTMLListItem` to format `$Rule.SendToManager.Manager.Reminders.Default.Reminder` and `$Rule.Reminders` using `Format-ReminderDays`.
  * Applied the `Format-ReminderDays` function to format `$Rule.SendToManager.ManagerNotCompliant.Reminders.Default.Reminder` and `$Rule.Reminders`.
  * Integrated the `Format-ReminderDays` function to format `$Rule.SendToManager.SecurityEscalation.Reminders.Default.Reminder` and `$Rule.Reminders`.

#### Configuration Update:
* [`Examples/Example-PasswordSolution-ModernConfiguration01.ps1`](diffhunk://#diff-6cd0a017c76e8ea96d42cefe1b018c5736344c01b6eaf0837bbd9178564f37a5L139-R139): Added new reminder days (600, -505) to the `New-PasswordConfigurationRule` for the 'All others' rule.